### PR TITLE
Create integration environment

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,8 +5,8 @@ provider "aws" {
 }
 
 module "ecs_base" {
-  source = "github.com/schramm-famm/bespin//modules/ecs_base"
-  name   = var.name
+  source             = "github.com/schramm-famm/bespin//modules/ecs_base"
+  name               = var.name
   enable_nat_gateway = true
 }
 
@@ -79,7 +79,7 @@ module "ether" {
   db_password     = var.rds_password
   content_dir     = "./"
   kafka_server    = "localhost:9092"
-  kafka_topic      = "updates"
+  kafka_topic     = "updates"
 }
 
 module "rds_instance" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,95 @@
+provider "aws" {
+  access_key = var.access_key
+  secret_key = var.secret_key
+  region     = var.region
+}
+
+module "ecs_base" {
+  source = "github.com/schramm-famm/bespin//modules/ecs_base"
+  name   = var.name
+  enable_nat_gateway = true
+}
+
+module "ecs_cluster" {
+  source                  = "github.com/schramm-famm/bespin//modules/ecs_cluster"
+  name                    = var.name
+  security_group_ids      = [aws_security_group.backend.id]
+  subnets                 = module.ecs_base.vpc_private_subnets
+  ec2_instance_profile_id = module.ecs_base.ecs_instance_profile_id
+}
+
+resource "aws_security_group" "load_balancer" {
+  name        = "${var.name}_load_balancer"
+  description = "Allow traffic into load balancer"
+  vpc_id      = module.ecs_base.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "backend" {
+  name        = "${var.name}_backend"
+  description = "Allow traffic for backend services"
+  vpc_id      = module.ecs_base.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 8081
+    to_port     = 8081
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+module "ether" {
+  source          = "./modules/ether"
+  name            = var.name
+  container_tag   = var.container_tag
+  port            = 80
+  cluster_id      = module.ecs_cluster.cluster_id
+  security_groups = [aws_security_group.load_balancer.id]
+  subnets         = module.ecs_base.vpc_public_subnets
+  internal        = false
+  db_location     = module.rds_instance.db_endpoint
+  db_username     = var.rds_username
+  db_password     = var.rds_password
+  content_dir     = "./"
+  kafka_server    = "localhost:9092"
+  kafka_topic      = "updates"
+}
+
+module "rds_instance" {
+  source          = "github.com/schramm-famm/bespin//modules/rds_instance"
+  name            = var.name
+  engine          = "mariadb"
+  engine_version  = "10.2.21"
+  port            = 3306
+  master_username = var.rds_username
+  master_password = var.rds_password
+  vpc_id          = module.ecs_base.vpc_id
+  subnet_ids      = module.ecs_base.vpc_private_subnets
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -81,7 +81,7 @@ resource "aws_security_group" "backend" {
 module "ether" {
   source          = "./modules/ether"
   name            = var.name
-  container_tag   = var.container_tag
+  container_tag   = var.ether_container_tag
   port            = 80
   cluster_id      = module.ecs_cluster.cluster_id
   security_groups = [aws_security_group.load_balancer.id]
@@ -92,7 +92,22 @@ module "ether" {
   db_password     = var.rds_password
   kafka_server    = split(",", aws_msk_cluster.main.bootstrap_brokers)[0]
   kafka_topic     = "updates"
+  karen_endpoint  = module.karen.elb_dns_name
   efs_id          = aws_efs_file_system.ether.id
+}
+
+module "karen" {
+  source          = "github.com/schramm-famm/karen//terraform/modules/karen"
+  name            = var.name
+  container_tag   = var.karen_container_tag
+  port            = 8081
+  cluster_id      = module.ecs_cluster.cluster_id
+  security_groups = [aws_security_group.load_balancer.id]
+  subnets         = module.ecs_base.vpc_private_subnets
+  internal        = true
+  db_location     = module.rds_instance.db_endpoint
+  db_username     = var.rds_username
+  db_password     = var.rds_password
 }
 
 module "rds_instance" {

--- a/terraform/modules/ether/main.tf
+++ b/terraform/modules/ether/main.tf
@@ -40,7 +40,7 @@ resource "aws_ecs_task_definition" "ether" {
         },
         {
             "name": "ETHER_CONTENT_DIR",
-            "value": "${var.content_dir}"
+            "value": "/tmp"
         },
         {
             "name": "ETHER_KAFKA_SERVER",
@@ -57,10 +57,24 @@ resource "aws_ecs_task_definition" "ether" {
         "hostPort": ${var.port},
         "protocol": "tcp"
       }
+    ],
+    "mountPoints": [
+      {
+        "sourceVolume": "efsVolume",
+        "containerPath": "/tmp"
+      }
     ]
   }
 ]
 EOF
+
+  volume {
+    name = "efsVolume"
+    efs_volume_configuration {
+      file_system_id = var.efs_id
+      root_directory = "/"
+    }
+  }
 }
 
 resource "aws_elb" "ether" {

--- a/terraform/modules/ether/main.tf
+++ b/terraform/modules/ether/main.tf
@@ -49,6 +49,10 @@ resource "aws_ecs_task_definition" "ether" {
         {
             "name": "ETHER_KAFKA_TOPIC",
             "value": "${var.kafka_topic}"
+        },
+        {
+            "name": "KAREN_SERVER",
+            "value": "${var.karen_endpoint}"
         }
     ],
     "portMappings": [

--- a/terraform/modules/ether/main.tf
+++ b/terraform/modules/ether/main.tf
@@ -1,0 +1,92 @@
+data "aws_region" "ether" {}
+
+resource "aws_cloudwatch_log_group" "ether" {
+  name              = "${var.name}_ether"
+  retention_in_days = 1
+}
+
+resource "aws_ecs_task_definition" "ether" {
+  family       = "${var.name}_ether"
+  network_mode = "bridge"
+
+  container_definitions = <<EOF
+[
+  {
+    "name": "${var.name}_ether",
+    "image": "343660461351.dkr.ecr.us-east-2.amazonaws.com/ether:${var.container_tag}",
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${aws_cloudwatch_log_group.ether.name}",
+            "awslogs-region": "${data.aws_region.ether.name}",
+            "awslogs-stream-prefix": "${var.name}"
+        }
+    },
+    "cpu": 10,
+    "memory": 128,
+    "essential": true,
+    "environment": [
+        {
+            "name": "ETHER_DB_LOCATION",
+            "value": "${var.db_location}"
+        },
+        {
+            "name": "ETHER_DB_USERNAME",
+            "value": "${var.db_username}"
+        },
+        {
+            "name": "ETHER_DB_PASSWORD",
+            "value": "${var.db_password}"
+        },
+        {
+            "name": "ETHER_CONTENT_DIR",
+            "value": "${var.content_dir}"
+        },
+        {
+            "name": "ETHER_KAFKA_SERVER",
+            "value": "${var.kafka_server}"
+        },
+        {
+            "name": "ETHER_KAFKA_TOPIC",
+            "value": "${var.kafka_topic}"
+        }
+    ],
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": ${var.port},
+        "protocol": "tcp"
+      }
+    ]
+  }
+]
+EOF
+}
+
+resource "aws_elb" "ether" {
+  name            = "${var.name}-ether"
+  subnets         = var.subnets
+  security_groups = var.security_groups
+  internal        = var.internal
+
+  listener {
+    instance_port     = var.port
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
+}
+
+resource "aws_ecs_service" "ether" {
+  name            = "${var.name}_ether"
+  cluster         = var.cluster_id
+  task_definition = aws_ecs_task_definition.ether.arn
+
+  load_balancer {
+    elb_name       = aws_elb.ether.name
+    container_name = "${var.name}_ether"
+    container_port = 80
+  }
+
+  desired_count = 1
+}

--- a/terraform/modules/ether/output.tf
+++ b/terraform/modules/ether/output.tf
@@ -1,0 +1,3 @@
+output "elb_dns_name" {
+  value = aws_elb.ether.dns_name
+}

--- a/terraform/modules/ether/variables.tf
+++ b/terraform/modules/ether/variables.tf
@@ -50,11 +50,6 @@ variable "db_password" {
   description = "Password for accessing the MariaDB server"
 }
 
-variable "content_dir" {
-  type        = string
-  description = "Directory in file system for storing HTML content files"
-}
-
 variable "kafka_server" {
   type        = string
   description = "Server where Kafka is running"
@@ -63,4 +58,9 @@ variable "kafka_server" {
 variable "kafka_topic" {
   type        = string
   description = "Kafka topic to read from"
+}
+
+variable "efs_id" {
+  type        = string
+  description = "ID of the EFS file system mounted on the container instances"
 }

--- a/terraform/modules/ether/variables.tf
+++ b/terraform/modules/ether/variables.tf
@@ -60,6 +60,11 @@ variable "kafka_topic" {
   description = "Kafka topic to read from"
 }
 
+variable "karen_endpoint" {
+  type        = string
+  description = "Endpoint for accessing the karen service"
+}
+
 variable "efs_id" {
   type        = string
   description = "ID of the EFS file system mounted on the container instances"

--- a/terraform/modules/ether/variables.tf
+++ b/terraform/modules/ether/variables.tf
@@ -1,0 +1,66 @@
+variable "name" {
+  type        = string
+  description = "Name used to identify resources"
+}
+
+variable "container_tag" {
+  type        = string
+  description = "Tag of the ether container in the registry to be used"
+  default     = "latest"
+}
+
+variable "port" {
+  type        = number
+  description = "The port that ether's container port will map to on the host"
+  default     = 80
+}
+
+variable "cluster_id" {
+  type        = string
+  description = "ID of the ECS cluster that the ether service will run in"
+}
+
+variable "security_groups" {
+  type        = list(string)
+  description = "VPC security groups for the ether service load balancer"
+}
+
+variable "subnets" {
+  type        = list(string)
+  description = "VPC subnets for the ether service load balancer"
+}
+
+variable "internal" {
+  type        = bool
+  description = "Toggle whether the load balancer will be internal"
+}
+
+variable "db_location" {
+  type        = string
+  description = "Location (host) of the MariaDB server"
+}
+
+variable "db_username" {
+  type        = string
+  description = "Username for accessing the MariaDB server"
+}
+
+variable "db_password" {
+  type        = string
+  description = "Password for accessing the MariaDB server"
+}
+
+variable "content_dir" {
+  type        = string
+  description = "Directory in file system for storing HTML content files"
+}
+
+variable "kafka_server" {
+  type        = string
+  description = "Server where Kafka is running"
+}
+
+variable "kafka_topic" {
+  type        = string
+  description = "Kafka topic to read from"
+}

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,0 +1,3 @@
+output "host" {
+  value = module.ether.elb_dns_name
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,36 @@
+variable "name" {
+  type        = string
+  description = "Name used to identify resources"
+}
+
+variable "access_key" {
+  type        = string
+  description = "AWS access key ID"
+}
+
+variable "secret_key" {
+  type        = string
+  description = "AWS secret access key"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region to deploy where resources will be deployed"
+  default     = "us-east-2"
+}
+
+variable "rds_username" {
+  type        = string
+  description = "Username for the master RDS user"
+}
+
+variable "rds_password" {
+  type        = string
+  description = "Password for the master RDS user"
+}
+
+variable "container_tag" {
+  type        = string
+  description = "Tag of the Docker container to be used in the ether container definition"
+  default     = "latest"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,8 +29,14 @@ variable "rds_password" {
   description = "Password for the master RDS user"
 }
 
-variable "container_tag" {
+variable "ether_container_tag" {
   type        = string
   description = "Tag of the Docker container to be used in the ether container definition"
+  default     = "latest"
+}
+
+variable "karen_container_tag" {
+  type        = string
+  description = "Tag of the Docker container to be used in the karen container definition"
   default     = "latest"
 }


### PR DESCRIPTION
Resolves #24 

The integration terraform config launches the `ether` module in AWS, along with Karen, EFS, Kafka, and MariaDB.